### PR TITLE
fixes to fdrCount, fetch function handler

### DIFF
--- a/esConnector.js
+++ b/esConnector.js
@@ -147,10 +147,10 @@ module.exports.esSearchResults = function(args, docType) {
     from: args.offset,
     size: args.limit
   };
-  console.time('esQuery');
+  // console.time('esQuery');
 
   return es.search(request).then((resp) => {
-    console.timeEnd('esQuery');
+    // console.timeEnd('esQuery');
     return resp.hits.hits;
   }).catch((e) => {
     logger.error(e);

--- a/schema.graphql
+++ b/schema.graphql
@@ -44,9 +44,9 @@ enum JobStatus {
   FAILED
 }
 
-type FdrCountsNumber {
-  levels: [Float]
-  counts: [Float]
+type FdrCounts {
+  levels: [Float!]!
+  counts: [Float!]!
 }
 
 type Dataset {
@@ -75,7 +75,7 @@ type Dataset {
   status: JobStatus
   inputPath: String
   uploadDateTime: String
-  fdrCounts(inpFdrLvls: [Float]): FdrCountsNumber
+  fdrCounts(inpFdrLvls: [Float!]!): FdrCounts!
 }
 
 # fields of categorical type
@@ -241,7 +241,7 @@ type Query {
   allDatasets(orderBy: DatasetOrderBy = ORDER_BY_DATE,
               sortingOrder: SortingOrder = DESCENDING,
               filter: DatasetFilter = {}, simpleQuery: String,
-              offset: Int = 0, limit: Int = 10, inpFdrLvls: [Float]): [Dataset!]!
+              offset: Int = 0, limit: Int = 10): [Dataset!]!
 
   allAnnotations(orderBy: AnnotationOrderBy = ORDER_BY_MSM,
                  sortingOrder: SortingOrder = DESCENDING,


### PR DESCRIPTION
Fixes after last code review:

- FdrCounts in resolver: level and counts should be always defined,
- New function to check if fetch successfully resolved (tested with wrong urls)
- Changes to async/await in optical image deletion - `forEach ` is changed to `for..of` since `forEach ` doesn't wait for resolving of promises in a loop